### PR TITLE
Fix for "apply all", which currently only applies one change at a time

### DIFF
--- a/lib/TwentyFifth/Migrations/Command/Apply.php
+++ b/lib/TwentyFifth/Migrations/Command/Apply.php
@@ -88,11 +88,7 @@ class Apply
                 $this->schema_manager->markMigration($shortname, $output);
                 $output->writeln(sprintf('Migration %s marked as applied.', $shortname));
             } else {
-                try {
-                    $this->schema_manager->executeMigration($shortname, $sql, $output);
-                } catch(\Exception $e) {
-                    return;
-                }
+                $this->schema_manager->executeMigration($shortname, $sql, $output);
             }
         }
     }

--- a/lib/TwentyFifth/Migrations/Command/Apply.php
+++ b/lib/TwentyFifth/Migrations/Command/Apply.php
@@ -88,9 +88,10 @@ class Apply
                 $this->schema_manager->markMigration($shortname, $output);
                 $output->writeln(sprintf('Migration %s marked as applied.', $shortname));
             } else {
-                $result = $this->schema_manager->executeMigration($shortname, $sql, $output);
-                if (!$result) {
-                    return;
+                try {
+                    $this->schema_manager->executeMigration($shortname, $sql, $output);
+                } catch(\Exception $e) {
+                    return
                 }
             }
         }

--- a/lib/TwentyFifth/Migrations/Command/Apply.php
+++ b/lib/TwentyFifth/Migrations/Command/Apply.php
@@ -91,7 +91,7 @@ class Apply
                 try {
                     $this->schema_manager->executeMigration($shortname, $sql, $output);
                 } catch(\Exception $e) {
-                    return
+                    return;
                 }
             }
         }


### PR DESCRIPTION
migrateAll() expected a return value from SchemaManagers's executeMigration() which no longer exists.
